### PR TITLE
setBufferedToImage in MainComponent

### DIFF
--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -12,6 +12,7 @@ MainComponent::MainComponent() :
     */
     
     setOpaque(true);
+    setBufferedToImage(true);
     setSize(600, 400);
     startTimerHz(8);
 }


### PR DESCRIPTION
Thanks very much for your work here, it is so useful to me!

Buffering the MainComponent to an image ensures that the previous frame is intact, which prevents flickering artefacts I was seeing. Just a little thing that sent me on a wild goose chase for an hour or so, where I added support for background colour index and eventually realised that wasn't the problem haha...